### PR TITLE
strip " for windows #46

### DIFF
--- a/packages/tygen-reflector/src/writer.ts
+++ b/packages/tygen-reflector/src/writer.ts
@@ -60,7 +60,7 @@ export class Writer {
 				return
 			}
 
-			let folder = path.join(this.outDir, reflection.id!.replace(/->|::/g, path.sep))
+			let folder = path.join(this.outDir, reflection.id!.replace(/->|::|"/g, path.sep))
 			let fileName = path.join(folder, 'index.json')
 
 			this.fs.mkdirpSync(folder)


### PR DESCRIPTION
The problem occurs when it writes out namespace modules such as the @types/node/inspector.d.ts `declare module "inspector"` which creates a `symbol.name = ""inspector""`. (prefix/suffix " around the name)

I tried my best to get the tygen repo building on my windows 10 machine but ran into a few problems that i could not conquer as I wanted to write a test as well.

So i have committed a quick fix that makes it work on my machine.

**windows dev compatibility** 

(I did not commit this, as the yarn.lock had lots of integrity changes)

To get it to partly work on my windows machine i added the `cross-env` package to root package.json and changed the way you set environment variables in the _tygen-html/package.json_

`"build": "cross-env NODE_ENV=production yarn run server-build && cross-env NODE_ENV=production yarn run client-build"`

Also in the same package.json file I had to update all of the parcel scripts by replacing  `'` to `\"`  to get them to at least execute on a windows machine.

eg `"client-build": "parcel build --detailed-report src/index.tsx --public-url \"/-/assets/\""`


